### PR TITLE
Use a reducer/partition-based method group grouping items

### DIFF
--- a/src/grouped-list.jsx
+++ b/src/grouped-list.jsx
@@ -1,32 +1,20 @@
 import React from 'react';
 import {
-	ap,
-	apply,
-	complement,
 	compose,
 	concat,
-	defaultTo,
-	find,
-	flip,
-	groupBy,
-	identity,
-	length,
-	of,
 	partition,
 	prop,
 	propEq
 } from 'ramda';
 
-const applicator = compose( flip( apply ), of ); // a -> (a -> b) -> b
-const pipe2 = flip( compose ); // (a -> b) -> (b -> c) -> (a -> c)
-const childProp = compose( pipe2( prop( 'props' ) ), prop ); // item -> string | undefined
-const findIn = flip( find ); // [a] -> (a -> bool) -> a | undefined
-const groupFilter = childProp( 'filter' ); // group -> ( item -> bool ) | undefined
-const groupName = prop( 'key' ); // group -> string | undefined
-const withDefaultGroup = defaultTo( { key: 'noGroupFound' } ); // (group | undefined) -> group
-const isTimeGroup = compose( propEq( 'displayName', 'GroupHeader' ), prop( 'type' ) ); // group -> bool
-const filterApplicator = compose( pipe2( groupFilter ), applicator ); // item -> (group -> bool)
-const propOf = flip( prop ); // a -> string -> b
+const groupFilter = compose( prop( 'filter' ), prop( 'props' ) );
+const hasMatches = a => a.length > 1;
+const isGroupHeader = compose( propEq( 'displayName', 'GroupHeader' ), prop( 'type' ) );
+const toFilteredGroups = ( [ groupList, remainingChildren ], nextGroup ) => {
+	const [ matched, notMatched ] = partition( groupFilter( nextGroup ), remainingChildren );
+
+	return [ [ ...groupList, [ nextGroup, ...matched ] ], notMatched ];
+};
 
 export const GroupedList = React.createClass( {
 	getInitialState() {
@@ -43,22 +31,14 @@ export const GroupedList = React.createClass( {
 
 	updateItems( allChildren ) {
 		const [
-			timeGroups,
+			groupHeaders,
 			children
-		] = partition( isTimeGroup, React.Children.toArray( allChildren ) );
+		] = partition( isGroupHeader, React.Children.toArray( allChildren ) );
 
-		const groupMatcher = compose( findIn( timeGroups ), filterApplicator );
-		const matchingGroupName = compose( groupName, withDefaultGroup, groupMatcher );
-
-		const groups = groupBy( matchingGroupName, children );
-		const groupItems = compose( defaultTo( [] ), propOf( groups ), groupName );
-		const groupHasItems = compose( Boolean, length, groupItems );
-
-		const flattenGroup = compose( ap( [ identity, groupItems ] ), of );
-
-		const items = timeGroups
-			.filter( groupHasItems )
-			.map( flattenGroup )
+		const items = groupHeaders
+			.reduce( toFilteredGroups, [ [], children ] )
+			.shift()
+			.filter( hasMatches )
 			.reduce( concat, [] );
 
 		this.setState( { items } );
@@ -82,5 +62,7 @@ export const GroupHeader = React.createClass( {
 		return <div className="list-group">{ children }</div>;
 	}
 } );
+
+GroupHeader.displayName = 'GroupHeader';
 
 export default GroupedList;


### PR DESCRIPTION
Previously a the children in the `<GroupedList />` component were sorted
and arranged through a compositional pipeline which was a bit verbose.

Now, the filtering process has been re-envisioned as a sequential
reduction wherein each step partitions the remaining children by the
current filter.

Props to @seanastephens for the idea
