### PR TITLE
Compare side-by-side with and without localStorage cache

### DIFF
--- a/localApp.jsx
+++ b/localApp.jsx
@@ -2,20 +2,56 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { applyMiddleware } from 'redux';
 import createLogger from 'redux-logger';
+import persistState from 'redux-localstorage';
+import { fromJSON, toJSON } from 'transit-immutable-js';
 
 import { AppFactory } from 'src/app';
 import RouteWrapper from 'routing-wrapper';
 import OAuthApp from 'oauth-wrapper';
 
-const RoutedApp = RouteWrapper( AppFactory, applyMiddleware( createLogger() ) );
+const containerStyle = {
+	width: '50%',
+	height: '100%',
+	float: 'left',
+	position: 'relative'
+}
+
+const RoutedApp = props => (
+	<div style={ containerStyle }>
+		{ RouteWrapper( AppFactory, applyMiddleware( createLogger() ) )( props ) }
+	</div>
+);
+
+const statePersister = persistState( null, {
+	serialize: toJSON,
+	deserialize: fromJSON
+} );
+
+const CachedApp = props => (
+	<div style={ containerStyle }>
+		{ React.createElement( AppFactory( statePersister ).App, props ) }
+	</div>
+);
 
 const clientId = 35604;
 const redirectPath = '/connect/response';
 
+const Tee = givenProps => {
+	const { children, ...props } = givenProps;
+
+	return (
+		<div>
+			{ React.Children.map( children, Child => React.cloneElement( Child, props ) ) }
+		</div>
+	);
+}
+
 ReactDOM.render(
 	<OAuthApp { ...{ clientId, redirectPath } }>
-		<RoutedApp />
+		<Tee>
+			<RoutedApp />
+			<CachedApp />
+		</Tee>
 	</OAuthApp>,
 	document.getElementById( 'root' )
 );
-

--- a/package.json
+++ b/package.json
@@ -52,7 +52,10 @@
     "react-dom": "0.14.7",
     "react-redux": "4.4.0",
     "redux": "3.3.1",
+    "redux-localstorage": "0.4.0",
     "redux-logger": "2.6.1",
+    "transit-immutable-js": "0.5.4",
+    "transit-js": "0.8.846",
     "whatwg-fetch": "0.11.0",
     "wpcom": "4.8.5"
   }


### PR DESCRIPTION
This version of the app builds with two copies of the notes client side-by-side, but instead of logging in to two separate accounts, the one of the left has no caching while the one on the right caches everything in `localStorage`. This allows you to compare the feel of the initial app load time.
